### PR TITLE
make target optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.nyc_output
+test_gen_files/

--- a/spec/fixtures/.mystiko_schema_validation_no_target.json
+++ b/spec/fixtures/.mystiko_schema_validation_no_target.json
@@ -1,0 +1,24 @@
+{
+  "environments": {
+    "dev": {
+      "region": "us-west-2",
+      "secrets": [
+        {
+          "name": "KEY_VALUE_SECRET1",
+          "keyValues": [
+            { "key": "SECRET_KEY1", "envname": "SECRET_KEY1_ENV" },
+            { "key": "SECRET_KEY3", "filename": "./test_gen_files/cert.crt" }
+          ]
+        },
+        {
+          "name": "test_name",
+          "envname": "test_env_name"
+        },
+        {
+          "name": "test_name2",
+          "filename": "test_file_name"
+        }
+      ]
+    }
+  }
+}

--- a/spec/invalid_target_spec.js
+++ b/spec/invalid_target_spec.js
@@ -7,7 +7,7 @@ describe('Invalid Target', function() {
       await mystiko({ env: 'test', configFile: './spec/fixtures/.mystiko_invalid_target.json'});
       passed = true;
     } catch (e) {
-      const expectedErrorMessage = `should match pattern \\"^(file|env)$\\"`;
+      const expectedErrorMessage = `Schema validation failed`;
       expect(e.message).toContain(expectedErrorMessage);
     }
     expect(passed).toEqual(false);

--- a/spec/process_secret_spec.js
+++ b/spec/process_secret_spec.js
@@ -50,4 +50,11 @@ describe('Process Secret', function() {
     const testFileContents = await fs.readFile(TEST_FILE_SECRET, 'utf8');
     expect(testFileContents).toEqual('MY SECRET FILE TEXT');
   });
+
+  it('should be able to set a plain text secret as an environment variable', async function() {
+    const secretConfig = { 'name': 'ASM_SECRET_NAME2', 'envname': 'PLAIN_TEXT_SECRET' };
+    const secretValue = 'secret value';
+    await processSecrets(secretValue, secretConfig);
+    expect(process.env.PLAIN_TEXT_SECRET).toBe(secretValue);
+  });
 });

--- a/spec/validate_schema_spec.js
+++ b/spec/validate_schema_spec.js
@@ -8,4 +8,9 @@ describe('Validate Schema', function() {
     const config = await fs.readFile('./spec/fixtures/.mystiko_schema_validation.json', 'utf8');
     validateSchema(JSON.parse(config));
   });
+
+  it('should validate the schema is correct without target', async function() {
+    const config = await fs.readFile('./spec/fixtures/.mystiko_schema_validation_no_target.json', 'utf8');
+    validateSchema(JSON.parse(config));
+  });
 });


### PR DESCRIPTION
* Make target optional in .mystiko.json file. If `envname` is present in the secret, use `target` of `env`. If `filename` is present in the secret, use `target` of `file`. One idea is to remove `target` all together, but that would be a breaking change, which is why I kept it, and just calculate it.
* Custom errors